### PR TITLE
Further improve process list UX

### DIFF
--- a/STROOP/Forms/StroopMainForm.Designer.cs
+++ b/STROOP/Forms/StroopMainForm.Designer.cs
@@ -206,6 +206,7 @@ namespace STROOP
             this.listBoxProcessesList.Name = "listBoxProcessesList";
             this.listBoxProcessesList.Size = new System.Drawing.Size(229, 95);
             this.listBoxProcessesList.TabIndex = 0;
+            this.listBoxProcessesList.DoubleClick += new System.EventHandler(this.listBoxProcessesList_DoubleClick);
             // 
             // labelFpsCounter
             // 

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -102,7 +102,12 @@ namespace STROOP
 
         private string GetDisplayNameForProcess(Process process)
         {
-            return $"{process.ProcessName} ({process.Id})";
+            if (process.MainWindowTitle == string.Empty)
+            {
+                return $"{process.ProcessName} ({process.Id})";
+            }
+            
+            return process.MainWindowTitle;
         }
         
         private void StroopMainForm_Load(object sender, EventArgs e)

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -100,6 +100,11 @@ namespace STROOP
             }
         }
 
+        private string GetDisplayNameForProcess(Process process)
+        {
+            return $"{process.ProcessName} ({process.Id})";
+        }
+        
         private void StroopMainForm_Load(object sender, EventArgs e)
         {
             Config.Stream.OnDisconnect += _sm64Stream_OnDisconnect;
@@ -472,7 +477,7 @@ namespace STROOP
             }
 
             panelConnect.Visible = false;
-            labelProcessSelect.Text = $"Connected To: {selectedProcess.MainWindowTitle}";
+            labelProcessSelect.Text = $"Connected To: {GetDisplayNameForProcess(selectedProcess)}";
         }
 
         private void buttonRefresh_Click(object sender, EventArgs e)
@@ -481,7 +486,7 @@ namespace STROOP
             listBoxProcessesList.Items.Clear();
             _availableProcesses = GetAvailableProcesses().OrderBy(p => p.StartTime).ToList();
             foreach (var process in _availableProcesses)
-                listBoxProcessesList.Items.Add(process.MainWindowTitle);
+                listBoxProcessesList.Items.Add(GetDisplayNameForProcess(process));
 
             // Pre-select the first process
             if (listBoxProcessesList.Items.Count != 0)

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -517,6 +517,11 @@ namespace STROOP
             buttonRefresh_Click(sender, e);
             buttonConnect_Click(sender, e);
         }
+        
+        private void listBoxProcessesList_DoubleClick(object sender, EventArgs e)
+        {
+            buttonConnect_Click(sender, e);
+        }
 
         private void trackBarObjSlotSize_ValueChanged(object sender, EventArgs e)
         {

--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -102,7 +102,7 @@ namespace STROOP
 
         private string GetDisplayNameForProcess(Process process)
         {
-            if (process.MainWindowTitle == string.Empty)
+            if (string.IsNullOrWhiteSpace(process.MainWindowTitle))
             {
                 return $"{process.ProcessName} ({process.Id})";
             }


### PR DESCRIPTION
In cases where the MainWindowTitle isn't available or incomplete, the list (along with the connection label) will show the process name and pid for disambiguation.

Additionally, double-clicking the process list will connect to the clicked process.