### PR TITLE
Fix double separator in map context menu

### DIFF
--- a/STROOP/Tabs/MapTab/MapTab.cs
+++ b/STROOP/Tabs/MapTab/MapTab.cs
@@ -487,7 +487,11 @@ namespace STROOP.Tabs.MapTab
             foreach (var a in hoverData)
                 a.AddContextMenuItems(this, contextMenu);
 
-            contextMenu.Items.Add(new ToolStripSeparator());
+            if (hoverData.Count > 0)
+            {
+                contextMenu.Items.Add(new ToolStripSeparator());
+            }
+            
             var openPopoutItem = new ToolStripMenuItem("Open Popout");
             openPopoutItem.Click += (e, args) =>
             {


### PR DESCRIPTION
When right-clicking on an empty spot with no objects on the map, the context menu has no object-specific items, but would have inserted a ToolStripSeparator after that section anyway.

That causes the second separator to appear directly below the first one, which looks unusual.

This commit fixes the described behaviour by only adding that separator when there are object-specific entries in the context menu.