### PR TITLE
Fix text rendering in map tab

### DIFF
--- a/STROOP/Resources/Shaders/Fullscreen.vert.glsl
+++ b/STROOP/Resources/Shaders/Fullscreen.vert.glsl
@@ -1,0 +1,16 @@
+﻿#version 330 core
+
+const vec2 positions[3] = vec2[](
+	vec2(-1, 1),
+	vec2(-1, -3),
+	vec2(3,  1)
+);
+
+out vec2 fs_texCoord;
+
+void main()
+{
+    gl_Position = vec4(positions[gl_VertexID], 0, 1);
+	fs_texCoord = (positions[gl_VertexID] + vec2(1)) * 0.5;
+	fs_texCoord.y = 1 - fs_texCoord.y;
+}

--- a/STROOP/Resources/Shaders/TextOverlay.frag.glsl
+++ b/STROOP/Resources/Shaders/TextOverlay.frag.glsl
@@ -1,0 +1,12 @@
+﻿#version 330 core
+
+in vec2 fs_texCoord;
+layout(location=0) out vec4 color;
+
+uniform sampler2D sampler;
+
+void main()
+{
+	// GDI is funny and actually swaps the red and blue channel - memesters
+	color = texture(sampler, fs_texCoord).bgra;
+}

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -1496,9 +1496,6 @@
     <PackageReference Include="OpenTK.GLControl">
       <Version>3.0.1</Version>
     </PackageReference>
-    <PackageReference Include="QuickFont.Desktop">
-      <Version>4.5.7053.25687</Version>
-    </PackageReference>
     <PackageReference Include="SharpFont">
       <Version>4.0.1</Version>
     </PackageReference>

--- a/STROOP/Tabs/BruteforceTab/Surfaces/GeneralPurpose/MethodControllers/RestrictHPosition.cs
+++ b/STROOP/Tabs/BruteforceTab/Surfaces/GeneralPurpose/MethodControllers/RestrictHPosition.cs
@@ -148,13 +148,11 @@ namespace STROOP.Tabs.BruteforceTab.Surfaces.GeneralPurpose.MethodControllers
                 var yaw = MoreMath.RadiansToAngleUnits(Math.Atan2(direction.X, direction.Z));
                 var b = arrowBase(graphics);
                 graphics.lineRenderer.AddArrow(b.X, b.Y, b.Z, len / graphics.MapViewScaleValue, (float)yaw, 20 / graphics.MapViewScaleValue, color, OutlineWidth);
-                Vector3 screenSpacePos = Vector3.TransformPosition(arrowTip, graphics.ViewMatrix);
-                screenSpacePos.Z = 0;
                 graphics.textRenderer.AddText(
-                    new[] { ($"RestrictHPosition ({parent.GetFuncIndex()?.ToString() ?? "-"})", Vector3.Zero) },
+                    $"RestrictHPosition ({parent.GetFuncIndex()?.ToString() ?? "-"})",
+                    arrowTip,
                     OutlineColor,
-                    Matrix4.CreateScale(1.0f / graphics.glControl.Height) * Matrix4.CreateTranslation(screenSpacePos),
-                    true);
+                    StringAlignment.Center);
             });
         }
         protected override void DrawOrthogonal(MapGraphics graphics) => DrawTopDown(graphics);

--- a/STROOP/Tabs/BruteforceTab/Surfaces/GeneralPurpose/MethodControllers/XZRadialLimit.cs
+++ b/STROOP/Tabs/BruteforceTab/Surfaces/GeneralPurpose/MethodControllers/XZRadialLimit.cs
@@ -119,13 +119,11 @@ namespace STROOP.Tabs.BruteforceTab.Surfaces.GeneralPurpose.MethodControllers
                                 2);
                     }
                 }
-                Vector3 screenSpacePos = Vector3.TransformPosition(new Vector3(x, 0, z), graphics.ViewMatrix);
-                screenSpacePos.Z = 0;
                 graphics.textRenderer.AddText(
-                    new[] { ($"XZRadialLimit ({parent.GetFuncIndex()?.ToString() ?? "-"})", Vector3.Zero) },
+                    $"XZRadialLimit ({parent.GetFuncIndex()?.ToString() ?? "-"})",
+                    new Vector3(x, 0, z),
                     OutlineColor,
-                    Matrix4.CreateScale(1.0f / graphics.glControl.Height) * Matrix4.CreateTranslation(screenSpacePos),
-                    true);
+                    StringAlignment.Center);
             });
 
         }

--- a/STROOP/Tabs/MapTab/MapGraphics.cs
+++ b/STROOP/Tabs/MapTab/MapGraphics.cs
@@ -16,6 +16,7 @@ namespace STROOP.Tabs.MapTab
         {
             FillBuffers,
             FillBuffersRedirect,
+            BakeText,
             Background,
             Geometry,
             Transparency,

--- a/STROOP/Tabs/MapTab/MapObjects/MapLineObject.cs
+++ b/STROOP/Tabs/MapTab/MapObjects/MapLineObject.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using STROOP.Utilities;
 using OpenTK;
-using System.Windows.Forms;
 
 namespace STROOP.Tabs.MapTab.MapObjects
 {
     public abstract class MapLineObject : MapObject
     {
+        protected override bool hasDragPoints => false;
+
         public MapLineObject() : base() { }
 
         protected virtual Vector4 GetColor(MapGraphics graphics) => ColorUtilities.ColorToVec4(OutlineColor, OpacityByte);
@@ -31,9 +32,7 @@ namespace STROOP.Tabs.MapTab.MapObjects
                 }
             });
         }
-
-        protected override ContextMenuStrip GetContextMenuStrip(MapTracker targetTracker) => new ContextMenuStrip();
-
+        
         protected override void DrawOrthogonal(MapGraphics graphics) => DrawTopDown(graphics);
 
         protected abstract List<Vector3> GetVertices(MapGraphics graphics);

--- a/STROOP/Tabs/MapTab/MapObjects/MapObject.cs
+++ b/STROOP/Tabs/MapTab/MapObjects/MapObject.cs
@@ -93,6 +93,8 @@ namespace STROOP.Tabs.MapTab.MapObjects
     {
         public readonly ObjectCreateParams creationParameters;
 
+        protected virtual bool hasDragPoints => true;
+
         ToolStripMenuItem itemEnableDragging = new ToolStripMenuItem("Enable dragging");
         ToolStripMenuItem itemEnableDraggingX = new ToolStripMenuItem("Enable X");
         ToolStripMenuItem itemEnableDraggingY = new ToolStripMenuItem("Enable Y");
@@ -265,14 +267,16 @@ namespace STROOP.Tabs.MapTab.MapObjects
         protected virtual ContextMenuStrip GetContextMenuStrip(MapTracker targetTracker)
         {
             var _contextMenuStrip = new ContextMenuStrip();
-            itemEnableDragging.Click += (_, __) => enableDragging = dragMask == DragMask.None;
-            foreach (var item_it in new[] { itemEnableDraggingX, itemEnableDraggingY, itemEnableDraggingZ, itemEnableDraggingAngle })
+            if (hasDragPoints)
             {
-                var item = item_it;
-                itemEnableDragging.DropDownItems.Add(item_it);
-                item_it.Click += (_, __) => item_it.Checked = !item_it.Checked;
+                itemEnableDragging.Click += (_, __) => enableDragging = dragMask == DragMask.None;
+                foreach (var item in new[] { itemEnableDraggingX, itemEnableDraggingY, itemEnableDraggingZ, itemEnableDraggingAngle })
+                {
+                    itemEnableDragging.DropDownItems.Add(item);
+                    item.Click += (_, __) => item.Checked = !item.Checked;
+                }
+                _contextMenuStrip.Items.Add(itemEnableDragging);
             }
-            _contextMenuStrip.Items.Add(itemEnableDragging);
 
             return _contextMenuStrip;
         }

--- a/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs
+++ b/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs
@@ -5,6 +5,7 @@ using STROOP.Utilities;
 using STROOP.Structs.Configurations;
 using System.Windows.Forms;
 using OpenTK;
+using System.Linq;
 
 namespace STROOP.Tabs.MapTab.MapObjects
 {
@@ -102,6 +103,8 @@ namespace STROOP.Tabs.MapTab.MapObjects
         Func<Vector3> aProvider, bProvider;
         TapeHoverData hoverData;
 
+        protected override bool hasDragPoints => true;
+
         public MapTapeMeasureObject()
         {
             OutlineColor = Color.Orange;
@@ -117,17 +120,9 @@ namespace STROOP.Tabs.MapTab.MapObjects
         protected override ContextMenuStrip GetContextMenuStrip(MapTracker targetTracker)
         {
             this.targetTracker = targetTracker;
-
-            itemEnableDragging = new ToolStripMenuItem("Enable dragging");
-            var capturedMapTab = currentMapTab;
-            itemEnableDragging.Click += (sender, e) =>
-            {
-                itemEnableDragging.Checked = !itemEnableDragging.Checked;
-            };
-
-            var _contextMenuStrip = new ContextMenuStrip();
-            _contextMenuStrip.Items.Add(itemEnableDragging);
-            itemEnableDragging.PerformClick();
+            
+            var _contextMenuStrip = base.GetContextMenuStrip(targetTracker);
+            _contextMenuStrip.Items.Cast<ToolStripItem>().FirstOrDefault(x => x.Text == "Enable dragging")?.PerformClick();
             return _contextMenuStrip;
         }
 

--- a/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs
+++ b/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs
@@ -195,12 +195,14 @@ namespace STROOP.Tabs.MapTab.MapObjects
                     Vector3 screenspacePoint = ssp.Xyz / ssp.W;
                     if (ssp.W < 0)
                         continue;
-                    graphics.textRenderer.AddText(
-                        new[] { ($"{nameString}: {(p1 - p2).Length}", Vector3.Zero) },
-                        lineColor,
-                        Matrix4.CreateTranslation(-16, 8, 0) * Matrix4.CreateScale(1.0f / graphics.glControl.Height) * Matrix4.CreateTranslation(screenspacePoint),
-                        screenSpace: true,
-                        align: QuickFont.QFontAlignment.Right);
+
+                    // TODO: render text again
+                    //graphics.textRenderer.AddText(
+                    //    new[] { ($"{nameString}: {(p1 - p2).Length}", Vector3.Zero) },
+                    //    lineColor,
+                    //    Matrix4.CreateTranslation(-16, 8, 0) * Matrix4.CreateScale(1.0f / graphics.glControl.Height) * Matrix4.CreateTranslation(screenspacePoint),
+                    //    screenSpace: true,
+                    //    align: QuickFont.QFontAlignment.Right);
                 }
             });
         }

--- a/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs
+++ b/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs
@@ -183,21 +183,7 @@ namespace STROOP.Tabs.MapTab.MapObjects
 
                     var lineColor = colors[colorIndex - 1];
                     graphics.lineRenderer.Add(p1, p2, ColorUtilities.ColorToVec4(lineColor), OutlineWidth);
-
-                    Vector3 middlePoint = (p1 + p2) * 0.5f;
-                    var ssp = Vector4.Transform(new Vector4(middlePoint.X, middlePoint.Y, middlePoint.Z, 1), graphics.ViewMatrix);
-
-                    Vector3 screenspacePoint = ssp.Xyz / ssp.W;
-                    if (ssp.W < 0)
-                        continue;
-
-                    // TODO: render text again
-                    //graphics.textRenderer.AddText(
-                    //    new[] { ($"{nameString}: {(p1 - p2).Length}", Vector3.Zero) },
-                    //    lineColor,
-                    //    Matrix4.CreateTranslation(-16, 8, 0) * Matrix4.CreateScale(1.0f / graphics.glControl.Height) * Matrix4.CreateTranslation(screenspacePoint),
-                    //    screenSpace: true,
-                    //    align: QuickFont.QFontAlignment.Right);
+                    graphics.textRenderer.AddText($"{nameString}: {(p1 - p2).Length}", (p1 + p2) * 0.5f, lineColor, StringAlignment.Far);
                 }
             });
         }

--- a/STROOP/Tabs/MapTab/Renderers/TextRenderer.cs
+++ b/STROOP/Tabs/MapTab/Renderers/TextRenderer.cs
@@ -1,21 +1,47 @@
-﻿using OpenTK.Graphics.OpenGL;
+﻿using OpenTK;
+using OpenTK.Graphics.OpenGL;
 using STROOP.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Imaging = System.Drawing.Imaging;
 
 namespace STROOP.Tabs.MapTab.Renderers
 {
+    using BrushCacheEntry = StrongBox<(Brush brush, int unusedCount)>;
+
     public class TextRenderer : Renderer
     {
+        const int BRUSH_UNUSED_COUNT_LIMIT = 120; // 4 seconds at 30 FPS
+
+        public static class Fonts
+        {
+            public static Font small = new Font("Consolas", 8);
+            public static Font medium = new Font("Consolas", 12);
+            public static Font large = new Font("Consolas", 24);
+        }
+
+        struct Text
+        {
+            public string value;
+            public StringFormat format;
+            public Font font;
+            public Brush brush;
+            public PointF position;
+        }
+
         int targetTexture;
         int shader;
         int uniform_sampler;
 
         Bitmap targetImage;
         Graphics gdiGraphics;
-        Font font;
+
+        List<Text> texts = new List<Text>();
+        Dictionary<Color, BrushCacheEntry> cachedBrushes = new Dictionary<Color, BrushCacheEntry>();
 
         protected virtual int GetShader() => GraphicsUtil.GetShaderProgram("Resources/Shaders/Fullscreen.vert.glsl", "Resources/Shaders/TextOverlay.frag.glsl");
 
@@ -29,7 +55,6 @@ namespace STROOP.Tabs.MapTab.Renderers
                 targetTexture = GL.GenTexture();
                 ResizeIfNecessary();
             });
-            font = new Font("Consolas", 60);
         }
 
         private void ResizeIfNecessary()
@@ -55,9 +80,21 @@ namespace STROOP.Tabs.MapTab.Renderers
             ResizeIfNecessary();
             graphics.drawLayers[(int)MapGraphics.DrawLayers.BakeText].Add(() =>
             {
-                // Draw some test content with GDI - we will later render text "instances" here
+                // Dispose of brushes that haven't been used in a while
+                var old = cachedBrushes;
+                cachedBrushes = new Dictionary<Color, BrushCacheEntry>();
+                foreach (var kvp in old)
+                    if (kvp.Value.Value.unusedCount++ < BRUSH_UNUSED_COUNT_LIMIT)
+                        cachedBrushes.Add(kvp.Key, kvp.Value);
+                    else
+                        kvp.Value.Value.brush.Dispose();
+
+                // Draw all collectext text instances, then clear the list for the next frame
                 gdiGraphics.Clear(Color.FromArgb(0));
-                gdiGraphics.DrawString("Test", font, Brushes.DarkGray, new Point(10, 20));
+                foreach (var t in texts)
+                    gdiGraphics.DrawString(t.value, t.font, t.brush, t.position, t.format);
+
+                texts.Clear();
                 gdiGraphics.Flush();
 
                 // Retrieve the rendered image data into a GL compatible array
@@ -87,6 +124,36 @@ namespace STROOP.Tabs.MapTab.Renderers
             });
         }
 
-        public void AddText(params object[] ignored) { }
+        public void AddText(string text, Vector3 position, Color color, StringAlignment alignment, Font font = null)
+        {
+            var graphics = AccessScope<MapTab>.content.graphics;
+            var ssp = Vector4.Transform(new Vector4(position.X, position.Y, position.Z, 1), graphics.ViewMatrix);
+
+            // clip texts behind the camera
+            if (ssp.W < 0)
+                return;
+
+            Vector3 screenspacePoint = ssp.Xyz / ssp.W;
+            texts.Add(new Text()
+            {
+                value = text,
+                brush = GetBrush(color),
+                font = font ?? Fonts.medium,
+                format = new StringFormat() { Alignment = alignment },
+                position = new PointF((screenspacePoint.X + 1) * targetImage.Width / 2f, (-screenspacePoint.Y + 1) * targetImage.Height / 2f),
+            });
+        }
+
+        Brush GetBrush(Color color)
+        {
+            BrushCacheEntry result;
+            if (!cachedBrushes.TryGetValue(color, out result))
+                cachedBrushes[color] = result = new BrushCacheEntry((new SolidBrush(color), 0));
+            else
+                result.Value.unusedCount = 0;
+
+            return result.Value.brush;
+
+        }
     }
 }

--- a/STROOP/Tabs/MapTab/Renderers/TextRenderer.cs
+++ b/STROOP/Tabs/MapTab/Renderers/TextRenderer.cs
@@ -1,100 +1,92 @@
-﻿using QuickFont;
-using OpenTK;
-using System.Collections.Generic;
-using System.Drawing;
-using System;
-using System.Reflection;
+﻿using OpenTK.Graphics.OpenGL;
 using STROOP.Utilities;
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using Imaging = System.Drawing.Imaging;
 
 namespace STROOP.Tabs.MapTab.Renderers
 {
     public class TextRenderer : Renderer
     {
-        struct TextBlock
-        {
-            public bool screenSpace;
-            public Matrix4 transform;
-            public QFontDrawingPrimitive primitive;
-        }
+        int targetTexture;
+        int shader;
+        int uniform_sampler;
 
-        QFontDrawing drawing;
-        QFont defaultFont;
-        List<TextBlock> primitiveBuffer = new List<TextBlock>();
-        bool textRenderingBroken => defaultFont == null;
+        Bitmap targetImage;
+        Graphics gdiGraphics;
+        Font font;
+
+        protected virtual int GetShader() => GraphicsUtil.GetShaderProgram("Resources/Shaders/Fullscreen.vert.glsl", "Resources/Shaders/TextOverlay.frag.glsl");
 
         public TextRenderer()
         {
             AccessScope<MapTab>.content.graphics.DoGLInit(() =>
             {
-                drawing = new QFontDrawing(false, null);
-                defaultFont = CreateDefaultFont();
+                shader = GetShader();
+                uniform_sampler = GL.GetUniformLocation(shader, "sampler");
+
+                targetTexture = GL.GenTexture();
+                ResizeIfNecessary();
             });
+            font = new Font("Consolas", 60);
         }
 
-        [System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptions()]
-        QFont CreateDefaultFont()
+        private void ResizeIfNecessary()
         {
-            try
-            {
-                //Check if freetype6 can be loaded
-                typeof(SharpFont.FT).GetMethod("FT_Init_FreeType", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, new object[] { null });
-                return new QFont(
-                    "Resources/Fonts/dejavu-markup/DejaVuMarkup.ttf",
-                    16,
-                    new QuickFont.Configuration.QFontBuilderConfiguration(),
-                    FontStyle.Regular
-                    );
-            }
-            catch (Exception ex)
-            {
-                string failString = "Text Rendering Initialization failed.\n";
-                System.Windows.Forms.MessageBox.Show($"{failString}{Utilities.ErrorUtilities.SeeLogFileText}");
-                Utilities.ErrorUtilities.WriteErrorLog($"{failString}{ex.ToString()}");
-            }
-            return null;
-        }
-
-        public void AddText(string text, Vector3 offset, Matrix4 transform, Color color, bool screenSpace = false, QFontAlignment align = QFontAlignment.Centre) =>
-            AddText(new[] { (text, offset) }, color, transform, screenSpace, align);
-
-
-        public void AddText(
-            (string text, Vector3 offset)[] textBlock, Color color, Matrix4 transform, bool screenSpace = false, QFontAlignment align = QFontAlignment.Centre)
-        {
-            if (textRenderingBroken)
+            var size = AccessScope<MapTab>.content.glControlMap2D;
+            if (size.Width == targetImage?.Size.Width && size.Height == targetImage.Size.Height)
                 return;
 
-            var prim = new QFontDrawingPrimitive(defaultFont);
-            prim.Options.Colour = color;
-            foreach (var v in textBlock)
-                prim.Print(v.text, v.offset, align);
-            primitiveBuffer.Add(new TextBlock { primitive = prim, transform = transform, screenSpace = screenSpace });
+            GL.BindTexture(TextureTarget.Texture2D, targetTexture);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, size.Width, size.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, IntPtr.Zero);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
+
+            targetImage?.Dispose();
+            gdiGraphics?.Dispose();
+            targetImage = new Bitmap(size.Width, size.Height, Imaging.PixelFormat.Format32bppArgb);
+            gdiGraphics = Graphics.FromImage(targetImage);
+            gdiGraphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
         }
 
         public override void SetDrawCalls(MapGraphics graphics)
         {
-            if (textRenderingBroken)
-                return;
+            ResizeIfNecessary();
+            graphics.drawLayers[(int)MapGraphics.DrawLayers.BakeText].Add(() =>
+            {
+                // Draw some test content with GDI - we will later render text "instances" here
+                gdiGraphics.Clear(Color.FromArgb(0));
+                gdiGraphics.DrawString("Test", font, Brushes.DarkGray, new Point(10, 20));
+                gdiGraphics.Flush();
 
-            primitiveBuffer.Clear();
+                // Retrieve the rendered image data into a GL compatible array
+                // This process swaps the red and blue channels due to GDI's storage format - the shader will swap these channels back.
+                var gdiData = targetImage.LockBits(new Rectangle(Point.Empty, targetImage.Size), Imaging.ImageLockMode.ReadOnly, Imaging.PixelFormat.Format32bppArgb);
+                var glData = new byte[targetImage.Width * targetImage.Height * 4];
+                int glStride = targetImage.Width * 4;
+                for (int row = 0; row < targetImage.Height; row++)
+                    Marshal.Copy(gdiData.Scan0 + row * gdiData.Stride, glData, row * glStride, glStride);
+                targetImage.UnlockBits(gdiData);
+
+                // Write the retrieved data to the texture
+                var gcHandle = GCHandle.Alloc(glData);
+                GL.BindTexture(TextureTarget.Texture2D, targetTexture);
+                GL.TexSubImage2D(TextureTarget.Texture2D, 0, 0, 0, targetImage.Size.Width, targetImage.Size.Height, PixelFormat.Rgba, PixelType.UnsignedByte, Marshal.UnsafeAddrOfPinnedArrayElement(glData, 0));
+                gcHandle.Free();
+            });
             graphics.drawLayers[(int)MapGraphics.DrawLayers.Overlay].Add(() =>
             {
-                drawing.DrawingPrimitives.Clear();
-                foreach (var primitive in primitiveBuffer)
-                {
-                    var knack = primitive.transform;
-                    if (!primitive.screenSpace)
-                        knack *= graphics.ViewMatrix;
-                    else
-                        primitive.primitive.Options.LockToPixel = true;
-                    primitive.primitive.ModelViewMatrix = knack;
-                    drawing.DrawingPrimitives.Add(primitive.primitive);
-                }
-                drawing.ProjectionMatrix = Matrix4.Identity;
-                drawing.RefreshBuffers();
-                drawing.Draw();
-                drawing.DisableShader();
+                GL.UseProgram(shader);
+                GL.Disable(EnableCap.DepthTest);
+                GL.Disable(EnableCap.CullFace);
+                GL.ActiveTexture(TextureUnit.Texture0);
+                GL.BindTexture(TextureTarget.Texture2D, targetTexture);
+                GL.Uniform1(uniform_sampler, (int)0);
+                GL.DrawArrays(PrimitiveType.Triangles, 0, 3);
             });
         }
+
+        public void AddText(params object[] ignored) { }
     }
 }


### PR DESCRIPTION
This replaces the [QuickFont](https://www.nuget.org/packages/QuickFont) based rendering method with a simple GDI method that renders into an offscreen image that is blended over the regular render result in the 'Overlay' stage.

Additionally, the "Enable dragging" option on the [MapTapeMeasureObject](../blob/Development/STROOP/Tabs/MapTab/MapObjects/MapTapeMeasureObject.cs) that has previously been broken has been restored.