### PR TITLE
ram start auto detection via 'CORE_RDRAM' mupen export

### DIFF
--- a/STROOP/Utilities/Kernal32NativeMethods.cs
+++ b/STROOP/Utilities/Kernal32NativeMethods.cs
@@ -56,6 +56,41 @@ namespace STROOP.Utilities
             public IntPtr VirtualAddress;
             public ulong VirtualAttributes;
         }
+        
+        /// <summary>
+        /// C# representation of SYMBOL_INFO in dbghelp.h. <para/>
+        /// https://learn.microsoft.com/de-de/windows/win32/api/dbghelp/ns-dbghelp-symbol_info <para/>
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        public struct Win32SymbolInfo
+        {
+            const int MaxSymbolLen = 2000;
+
+            public static Win32SymbolInfo Create()
+                => new Win32SymbolInfo
+                {
+                    MaxNameLen = MaxSymbolLen,
+                    SizeOfStruct = 88
+                };
+
+            public int SizeOfStruct;
+            public int TypeIndex;
+            readonly ulong Reserved1, Reserved2;
+            public int Index;
+            public int Size;
+            public ulong ModuleBase;
+            public uint Flags;
+            public long Value;
+            public ulong Address;
+            public uint Register;
+            public uint Scope;
+            public uint Tag;
+            public uint NameLen;
+            public int MaxNameLen;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MaxSymbolLen)]
+            public string Name;
+        }
 
         #region DLL Import
         [DllImport("kernel32.dll")]
@@ -86,6 +121,13 @@ namespace STROOP.Utilities
 
         [DllImport("psapi", SetLastError = true)]
         static extern bool QueryWorkingSetEx(IntPtr hProcess, out PsapiWorkingSetExInformation pv, uint cb);
+
+        [DllImport("dbghelp", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "SymInitializeW", ExactSpelling = true)]
+        public static extern bool SymInitialize(IntPtr hProcess, string searchPath, bool invadeProcess);
+        
+        [DllImport("dbghelp", SetLastError = true)]
+        public static extern bool SymFromName(IntPtr hProcess, string name, ref Win32SymbolInfo win32Symbol);
+        
         #endregion
 
         public static IntPtr ProcessGetHandleFromId(ProcessAccess dwDesiredAccess, bool bInheritHandle, int dwProcessId)

--- a/STROOP/Utilities/Kernal32NativeMethods.cs
+++ b/STROOP/Utilities/Kernal32NativeMethods.cs
@@ -128,6 +128,10 @@ namespace STROOP.Utilities
         [DllImport("dbghelp", SetLastError = true)]
         public static extern bool SymFromName(IntPtr hProcess, string name, ref Win32SymbolInfo win32Symbol);
         
+        [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWow64Process([In] IntPtr process, [Out] out bool wow64Process);
+
         #endregion
 
         public static IntPtr ProcessGetHandleFromId(ProcessAccess dwDesiredAccess, bool bInheritHandle, int dwProcessId)

--- a/STROOP/Utilities/Stream/WindowsProcessIO.cs
+++ b/STROOP/Utilities/Stream/WindowsProcessIO.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using static STROOP.Utilities.Kernal32NativeMethods;
 
 namespace STROOP.Utilities
@@ -33,7 +34,7 @@ namespace STROOP.Utilities
             _process.EnableRaisingEvents = true;
 
             ProcessAccess accessFlags = ProcessAccess.PROCESS_QUERY_LIMITED_INFORMATION | ProcessAccess.SUSPEND_RESUME
-                | ProcessAccess.VM_OPERATION | ProcessAccess.VM_READ | ProcessAccess.VM_WRITE;
+                                                                                        | ProcessAccess.VM_OPERATION | ProcessAccess.VM_READ | ProcessAccess.VM_WRITE;
             _processHandle = ProcessGetHandleFromId(accessFlags, false, _process.Id);
             try
             {
@@ -90,9 +91,19 @@ namespace STROOP.Utilities
                     return false;
             return true;
         }
-
+        
         protected virtual void CalculateOffset()
         {
+            // Find CORE_RDRAM export from mupen if present
+            Win32SymbolInfo smybolInfo = Win32SymbolInfo.Create();
+            if (SymInitialize(_process.Handle, null, true) && SymFromName(_process.Handle, "CORE_RDRAM", ref smybolInfo))
+            {
+                var val = new byte[4];
+                ReadAbsolute((UIntPtr)smybolInfo.Address, val, EndiannessType.Little);
+                _baseOffset = BitConverter.ToUInt32(val, 0);
+                return;
+            }
+            
             // Find DLL offset if needed
             IntPtr dllOffset = new IntPtr();
 

--- a/STROOP/Utilities/Stream/WindowsProcessIO.cs
+++ b/STROOP/Utilities/Stream/WindowsProcessIO.cs
@@ -1,6 +1,7 @@
 ﻿using STROOP.Structs;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -91,19 +92,27 @@ namespace STROOP.Utilities
                     return false;
             return true;
         }
-        
+
+        // see https://msdn.microsoft.com/en-us/library/windows/desktop/ms684139%28v=vs.85%29.aspx
+        public static bool Is64Bit(Process process)
+            => Environment.Is64BitOperatingSystem
+               && IsWow64Process(process.Handle, out bool isWow64)
+                ? !isWow64
+                : throw new Win32Exception();
+
         protected virtual void CalculateOffset()
         {
             // Find CORE_RDRAM export from mupen if present
             Win32SymbolInfo smybolInfo = Win32SymbolInfo.Create();
             if (SymInitialize(_process.Handle, null, true) && SymFromName(_process.Handle, "CORE_RDRAM", ref smybolInfo))
             {
-                var val = new byte[4];
-                ReadAbsolute((UIntPtr)smybolInfo.Address, val, EndiannessType.Little);
-                _baseOffset = BitConverter.ToUInt32(val, 0);
+                var is64Bit = Is64Bit(_process);
+                var buffer = new byte[is64Bit ? 8 : 4];
+                ReadAbsolute((UIntPtr)smybolInfo.Address, buffer, EndiannessType.Little);
+                _baseOffset = (UIntPtr)(is64Bit ? BitConverter.ToUInt64(buffer, 0) : (ulong)BitConverter.ToUInt32(buffer, 0));
                 return;
             }
-            
+
             // Find DLL offset if needed
             IntPtr dllOffset = new IntPtr();
 
@@ -150,19 +159,21 @@ namespace STROOP.Utilities
                         break;
                 }
             }
+
             messageLogBuilder.AppendLine("Unable to verify or correct RAM start.\r\nVerify that the game is currently running.");
-        verified:;
+            verified: ;
 
             bool VerifyCandidate(UIntPtr candidate)
             {
                 try
                 {
                     var mem = new byte[0x200];
-                    var expectedSignature = new byte?[] {
-                         null,0x80,0x1a, 0x3c,
-                         null,null,0x5a, 0x27,
-                         0x08,0x00,0x40, 0x03,
-                         0x00,0x00,0x00, 0x00,
+                    var expectedSignature = new byte?[]
+                    {
+                        null, 0x80, 0x1a, 0x3c,
+                        null, null, 0x5a, 0x27,
+                        0x08, 0x00, 0x40, 0x03,
+                        0x00, 0x00, 0x00, 0x00,
                     };
                     if (!ReadFunc(candidate, mem))
                         return false;
@@ -181,7 +192,10 @@ namespace STROOP.Utilities
                                 return false;
                 }
                 catch (Exception e)
-                { return false; }
+                {
+                    return false;
+                }
+
                 return true;
             }
         }
@@ -202,6 +216,7 @@ namespace STROOP.Utilities
         }
 
         #region IDisposable Support
+
         private bool disposedValue = false; // To detect redundant calls
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
closes #18 

Using `NativeLibrary.Load` fails due to platform architecture differences, which is why the `dbghelp` PInvoke approach was taken instead.

#17 should be merged first, even though the changes should be independent; switching between .NET Framework and .NET builds is pain for stupid reasons...