### PR TITLE
Set seperator for position copy to ','

### DIFF
--- a/STROOP/Utilities/CopyUtilities.cs
+++ b/STROOP/Utilities/CopyUtilities.cs
@@ -76,7 +76,7 @@ namespace STROOP.Utilities
         public static void CopyPosition(Vector3 v)
         {
             DataObject vec3Data = new DataObject("Position", v);
-            vec3Data.SetText($"{v.X}; {v.Y}; {v.Z}");
+            vec3Data.SetText($"{v.X}, {v.Y}, {v.Z}");
             Clipboard.SetDataObject(vec3Data);
         }
 

--- a/STROOP/Utilities/CopyUtilities.cs
+++ b/STROOP/Utilities/CopyUtilities.cs
@@ -43,8 +43,6 @@ namespace STROOP.Utilities
                 "Copy with Line Breaks",
                 "Copy with Commas and Spaces",
                 "Copy with Names",
-                "Copy as Table",
-                "Copy for Code",
             };
         }
 
@@ -58,8 +56,6 @@ namespace STROOP.Utilities
                 () => CopyWithSeparator(getVars(), "\r\n"),
                 () => CopyWithSeparator(getVars(), ", "),
                 () => CopyWithNames(getVars()),
-                () => CopyAsTable(getVars()),
-                () => CopyForCode(getVars()),
             };
         }
 
@@ -75,61 +71,6 @@ namespace STROOP.Utilities
             if (controls.Count == 0) return;
             List<string> lines = controls.ConvertAll(watchVar => watchVar.VarName + "\t" + watchVar.WatchVarWrapper.GetValueText());
             Clipboard.SetText(string.Join("\r\n", lines));
-        }
-
-        private static void CopyAsTable(List<WatchVariableControl> controls)
-        {
-            // TODO: reconsider CopyAsTable
-            //if (controls.Count == 0) return;
-            //List<string> hexAddresses = controls.Select(x => x.view as NamedVariableCollection.MemoryDescriptorView).Where(x => x != null).ConvertAll(address => HexUtilities.FormatValue(address));
-            //string header = "Vars\t" + string.Join("\t", hexAddresses);
-
-            //List<string> names = controls.ConvertAll(control => control.VarName);
-            //List<List<object>> valuesTable = controls.ConvertAll(control => control.view.GetValues());
-            //List<string> valuesStrings = new List<string>();
-            //for (int i = 0; i < names.Count; i++)
-            //{
-            //    string line = names[i] + "\t" + string.Join("\t", valuesTable[i]);
-            //    valuesStrings.Add(line);
-            //}
-
-            //string output = header + "\r\n" + string.Join("\r\n", valuesStrings);
-            //Clipboard.SetText(output);
-        }
-
-        private static void CopyForCode(List<WatchVariableControl> controls)
-        {
-            if (controls.Count == 0) return;
-            Func<string, string> varNameFunc;
-            if (GlobalKeyboard.IsCtrlDown())
-            {
-                string template = DialogUtilities.GetStringFromDialog("$");
-                if (template == null) return;
-                varNameFunc = varName => template.Replace("$", varName);
-            }
-            else
-            {
-                varNameFunc = varName => varName;
-            }
-
-            List<string> lines = new List<string>();
-            foreach (WatchVariableControl watchVar in controls)
-            {
-                Type type = watchVar.GetMemoryType();
-                string line = string.Format(
-                    "{0} {1} = {2}{3};",
-                    type != null ? TypeUtilities.TypeToString[type] : "double",
-                    varNameFunc(watchVar.VarName.Replace(" ", "")),
-                    // TODO: indicate that the watchVarWrapper should produce code conforming output (whatever that means)
-                    watchVar.WatchVarWrapper.GetValueText(),
-                    type == typeof(float) ? "f" : "");
-                lines.Add(line);
-            }
-
-            if (lines.Count > 0)
-            {
-                Clipboard.SetText(string.Join("\r\n", lines));
-            }
         }
 
         public static void CopyPosition(Vector3 v)


### PR DESCRIPTION
This fixes the "Copy ... Position" options (particularly in the map tab) to use the `,` charactar as a separator instead of `;`.  
It also removes the options "Copy as Table" and "Copy for Code" options from the variable panel copy options, because they were not implemented at all or not impemented properly.