### PR TITLE
Fix keys getting "stuck" under certain conditions

### DIFF
--- a/STROOP/Forms/StroopMainForm.cs
+++ b/STROOP/Forms/StroopMainForm.cs
@@ -48,7 +48,6 @@ namespace STROOP
         {
             this.searchVariableDialog = new SearchVariableDialog(this);
             this.isMainForm = isMainForm;
-            GlobalKeyboard.AddForm(this);
             InitializeComponent();
             InitTabs();
             ObjectSlotsManager = new ObjectSlotsManager(this, tabControlMain);

--- a/STROOP/Utilities/GlobalKeyboard.cs
+++ b/STROOP/Utilities/GlobalKeyboard.cs
@@ -1,51 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
+using Windows.Win32;
 
 namespace STROOP.Utilities;
 
 public static class GlobalKeyboard
 {
-    static HashSet<Keys> pressedKeys = new();
-    static HashSet<Form> registeredForms = new();
+    private static bool IsDownInternal(Keys key)
+        => (PInvoke.GetAsyncKeyState((int)key) & 0x8000) != 0;
 
-    public static void AddForm(Form form)
-    {
-        registeredForms.Add(form);
-        form.KeyPreview = true;
-        form.KeyDown += OnKeyDown;
-        form.KeyUp += OnKeyUp;
+    public static bool IsDown(Keys key) => IsDownInternal(key);
 
-        EventHandler unbind = null;
-        unbind = (sender, e) =>
-        {
-            registeredForms.Remove(form);
-            ((Form)sender).Disposed -= unbind;
-            form.KeyDown -= OnKeyDown;
-            form.KeyUp -= OnKeyUp;
-        };
-        form.Disposed += unbind;
-    }
-
-    public static bool IsDown(Keys key) => pressedKeys.Contains(key) && registeredForms.Any(f => Form.ActiveForm == f);
-
-    public static bool IsCtrlDown() => pressedKeys.Contains(Keys.ControlKey);
-    public static bool IsShiftDown() => pressedKeys.Contains(Keys.ShiftKey);
-    public static bool IsAltDown() => pressedKeys.Contains(Keys.Menu) || pressedKeys.Contains(Keys.Alt); // Don't ask me why...
+    public static bool IsCtrlDown() => IsDown(Keys.ControlKey);
+    public static bool IsShiftDown() => IsDown(Keys.ShiftKey);
+    public static bool IsAltDown() => IsDown(Keys.Menu) || IsDown(Keys.Alt); // Don't ask me why...
 
     public static int? GetCurrentlyInputtedNumber()
     {
-        if (pressedKeys.Contains(Keys.D1)) return 1;
-        if (pressedKeys.Contains(Keys.D2)) return 2;
-        if (pressedKeys.Contains(Keys.D3)) return 3;
-        if (pressedKeys.Contains(Keys.D4)) return 4;
-        if (pressedKeys.Contains(Keys.D5)) return 5;
-        if (pressedKeys.Contains(Keys.D6)) return 6;
-        if (pressedKeys.Contains(Keys.D7)) return 7;
-        if (pressedKeys.Contains(Keys.D8)) return 8;
-        if (pressedKeys.Contains(Keys.D9)) return 9;
-        if (pressedKeys.Contains(Keys.D0)) return 0;
+        if (IsDown(Keys.D1)) return 1;
+        if (IsDown(Keys.D2)) return 2;
+        if (IsDown(Keys.D3)) return 3;
+        if (IsDown(Keys.D4)) return 4;
+        if (IsDown(Keys.D5)) return 5;
+        if (IsDown(Keys.D6)) return 6;
+        if (IsDown(Keys.D7)) return 7;
+        if (IsDown(Keys.D8)) return 8;
+        if (IsDown(Keys.D9)) return 9;
+        if (IsDown(Keys.D0)) return 0;
         return null;
     }
 
@@ -60,10 +40,4 @@ public static class GlobalKeyboard
                IsDown(Keys.Back) ||
                IsDown(Keys.Escape);
     }
-
-    private static void OnKeyDown(object sender, KeyEventArgs e)
-        => pressedKeys.Add(e.KeyCode);
-
-    private static void OnKeyUp(object sender, KeyEventArgs e)
-        => pressedKeys.Remove(e.KeyCode);
 }


### PR DESCRIPTION
This should eliminate issues of keys being "stuck" (i.e. not actually pressed but considered pressed) in places where the keyboard state is queried to modify an action, e.g. by holding down the Ctrl Key while clicking on something.