### PR TITLE
Update to .NET 10

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -1,4 +1,4 @@
-# .github/workflows/debug-build.yml
+﻿# .github/workflows/debug-build.yml
 name: PR Debug Build (Development)
 
 on:
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If this updated feature set doesn't suit your needs, you can of course still get
   As of the current build, STROOP has the following system requirements:
   * Windows 11 / Windows 10 / Windows 8.1 / Windows 8 / Windows 7 64-bit or 32-bit
   * OpenGL 3.2 or greater
-  * [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) or higher
+  * [.NET 10.0 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) or higher
   * [Mupen](https://mupen64.com/) is recommended for TASing. (Nemu64 and some other emulators may work, but that's a bit of a shot in the dark)
   * 64 Marios (Must be super)
   * Marios must be American, Japanese or PAL
@@ -30,7 +30,7 @@ If this updated feature set doesn't suit your needs, you can of course still get
 ## Building
 
 Requirements:
-  * A [dotnet 8.0 (or higher) SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) in any capacity
+  * A [dotnet 10.0 (or higher) SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) in any capacity
   * An internet connection for the [NuGet](https://nuget.org) package dependencies, such as OpenTK.
 
 A simple `dotnet build` in the repository root directory will create a debug build.<br>

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows7.0</TargetFramework>
         <OutputType>WinExe</OutputType>
         <UseWindowsForms>true</UseWindowsForms>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/STROOP/STROOP.csproj
+++ b/STROOP/STROOP.csproj
@@ -291,5 +291,7 @@
         <ProjectReference Include="..\STROOP.Core\STROOP.Core.csproj"/>
         <ProjectReference Include="..\STROOP.Variables\STROOP.Variables.csproj" />
     </ItemGroup>
-
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);WFO1000</NoWarn>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Rationale is that this will allow us to use the `Application.SetColorMode` API to add back dark mode.

That API exists since .NET 9, but 10 is an LTS release so might as well