### PR TITLE
fix: map popout rendering by presenting through its own GL context

### DIFF
--- a/STROOP/Tabs/MapTab/MapGraphics.cs
+++ b/STROOP/Tabs/MapTab/MapGraphics.cs
@@ -358,6 +358,14 @@ namespace STROOP.Tabs.MapTab
 
         public void CleanUp()
         {
+            if (getContext != null)
+            {
+                // The presentFrameBuffer is created specifically and exclusively in the "popout" context of the glControl this instance shall render to.
+                // Temporarily switch contexts to free the name of the framebuffer as early as possible.
+                glControl.Context!.MakeCurrent();
+                GL.DeleteFramebuffer(presentFrameBuffer);
+                getContext().MakeCurrent();
+            }
             transparencyRenderer.CleanUp();
             DeleteMainSurfaces();
         }

--- a/STROOP/Tabs/MapTab/MapGraphics.cs
+++ b/STROOP/Tabs/MapTab/MapGraphics.cs
@@ -76,6 +76,10 @@ namespace STROOP.Tabs.MapTab
 
         int mainFrameBuffer, mainColorBuffer, mainDepthBuffer;
 
+        // Only used when rendering into a foreign (shared) context - see OnPaint. This FBO lives in
+        // THIS control's own context and wraps the shared color texture so we can blit it to our window.
+        int presentFrameBuffer;
+
         public class CachedCollisionStructure
         {
             readonly TriangleClassification filter;
@@ -290,6 +294,8 @@ namespace STROOP.Tabs.MapTab
                 if (glControl.Width * glControl.Height > 0)
                     using (new AccessScope<MapTab>(mapTab))
                     {
+                        // These surfaces live in the render context (the main map's, for popouts).
+                        (getContext != null ? getContext() : glControl.Context).MakeCurrent();
                         DeleteMainSurfaces();
                         transparencyRenderer.SetDimensions(glControl.Width, glControl.Height);
                         InitMainSurfaces();
@@ -358,6 +364,10 @@ namespace STROOP.Tabs.MapTab
 
         private void OnPaint()
         {
+            // Everything is rendered in the "render context": our own context for the main map, or the
+            // main map's shared context for popouts. Make it current before any GL call (incl. GL init).
+            (getContext != null ? getContext() : glControl.Context).MakeCurrent();
+
             PerformGLInit();
 
             if (Config.Stream == null || rendererCollection == null)
@@ -370,7 +380,6 @@ namespace STROOP.Tabs.MapTab
                 if (glControl.Cursor != cursor)
                     glControl.Cursor = cursor;
 
-                (getContext != null ? getContext() : glControl.Context).MakeCurrent();
                 UpdateMapView();
 
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, mainFrameBuffer);
@@ -409,11 +418,30 @@ namespace STROOP.Tabs.MapTab
                     foreach (var action in layer)
                         action.Invoke();
 
-                GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, 0);
-                GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, mainFrameBuffer);
-                GL.BlitFramebuffer(0, 0, glControl.Width, glControl.Height, 0, 0, glControl.Width, glControl.Height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
-
-                glControl.SwapBuffers();
+                if (getContext == null)
+                {
+                    // Main map: render context == our own context. Blit our FBO to our window directly.
+                    GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, 0);
+                    GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, mainFrameBuffer);
+                    GL.BlitFramebuffer(0, 0, glControl.Width, glControl.Height, 0, 0, glControl.Width, glControl.Height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
+                    glControl.SwapBuffers();
+                }
+                else
+                {
+                    // Popout: we rendered in the shared (main) context. Present into OUR own context/window
+                    // by blitting the shared color texture (valid via GLControl.SharedContext) through a
+                    // present-FBO that lives in our context. This is the fix for issue #39: the old code
+                    // blitted into the main window and swapped our never-rendered buffer.
+                    GL.Flush();
+                    glControl.MakeCurrent();
+                    if (presentFrameBuffer == 0)
+                        presentFrameBuffer = GL.GenFramebuffer();
+                    GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, presentFrameBuffer);
+                    GL.FramebufferTexture(FramebufferTarget.ReadFramebuffer, FramebufferAttachment.ColorAttachment0, mainColorBuffer, 0);
+                    GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, 0);
+                    GL.BlitFramebuffer(0, 0, glControl.Width, glControl.Height, 0, 0, glControl.Width, glControl.Height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
+                    glControl.SwapBuffers();
+                }
             }
         }
 

--- a/STROOP/Tabs/MapTab/MapGraphics.cs
+++ b/STROOP/Tabs/MapTab/MapGraphics.cs
@@ -310,6 +310,7 @@ namespace STROOP.Tabs.MapTab
                         DeleteMainSurfaces();
                         transparencyRenderer.SetDimensions(glControl.Width, glControl.Height);
                         InitMainSurfaces();
+                        InitOrUpdatePresentFrameBuffer();
                     }
             };
 
@@ -323,6 +324,7 @@ namespace STROOP.Tabs.MapTab
                 GL.Hint(HintTarget.PerspectiveCorrectionHint, HintMode.Nicest);
 
                 InitMainSurfaces();
+                InitOrUpdatePresentFrameBuffer();
             });
 
             rendererCollection = getRenderers();
@@ -363,6 +365,20 @@ namespace STROOP.Tabs.MapTab
             FramebufferErrorCode error;
             if ((error = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)) != FramebufferErrorCode.FramebufferComplete)
                 throw null;
+
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        }
+
+        void InitOrUpdatePresentFrameBuffer()
+        {
+            // Only needed for Map popouts
+            if (getContext == null) return;
+
+            glControl.MakeCurrent();
+            if (presentFrameBuffer == 0)
+                presentFrameBuffer = GL.GenFramebuffer();
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, presentFrameBuffer);
+            GL.FramebufferTexture(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, mainColorBuffer, 0);
 
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
         }
@@ -445,16 +461,13 @@ namespace STROOP.Tabs.MapTab
                 }
                 else
                 {
-                    // Popout: we rendered in the shared (main) context. Present into OUR own context/window
+                    // Popout: We rendered in the host context. Present into OUR own context/window
                     // by blitting the shared color texture (valid via GLControl.SharedContext) through a
                     // present-FBO that lives in our context. This is the fix for issue #39: the old code
                     // blitted into the main window and swapped our never-rendered buffer.
                     GL.Flush();
                     glControl.MakeCurrent();
-                    if (presentFrameBuffer == 0)
-                        presentFrameBuffer = GL.GenFramebuffer();
                     GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, presentFrameBuffer);
-                    GL.FramebufferTexture(FramebufferTarget.ReadFramebuffer, FramebufferAttachment.ColorAttachment0, mainColorBuffer, 0);
                     GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, 0);
                     GL.BlitFramebuffer(0, 0, glControl.Width, glControl.Height, 0, 0, glControl.Width, glControl.Height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
                     glControl.SwapBuffers();

--- a/STROOP/Tabs/MapTab/MapGraphics.cs
+++ b/STROOP/Tabs/MapTab/MapGraphics.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using System.Drawing;
 using OpenTK.GLControl;
 using OpenTK.Mathematics;
+using OpenTK.Windowing.Common;
 using STROOP.Controls;
 using STROOP.Core;
 using STROOP.Extensions;
@@ -216,9 +217,19 @@ namespace STROOP.Tabs.MapTab
 
         public readonly KeyboardControls keyboardControls;
 
-        Func<OpenTK.Windowing.Common.IGraphicsContext> getContext;
+        Func<IGraphicsContext> getContext;
 
-        public MapGraphics(MapTab mapTab, GLControl glControl, Func<OpenTK.Windowing.Common.IGraphicsContext> getContext = null)
+        /// <summary>
+        /// The OpenGL context that hosts all resources necessary to render a complete map image,
+        /// and is capable of rendering to the main window's Map tab.
+        /// <para>
+        /// Popout windows' <see cref="MapPopout.graphics"/> instances will share with this context,
+        /// but blit to their own framebuffer before presenting.
+        /// </para>
+        /// </summary>
+        IGraphicsContext hostGlContext => getContext != null ? getContext() : glControl.Context;
+
+        public MapGraphics(MapTab mapTab, GLControl glControl, Func<IGraphicsContext> getContext = null)
         {
             this.mapTab = mapTab;
             this.glControl = glControl;
@@ -294,8 +305,8 @@ namespace STROOP.Tabs.MapTab
                 if (glControl.Width * glControl.Height > 0)
                     using (new AccessScope<MapTab>(mapTab))
                     {
-                        // These surfaces live in the render context (the main map's, for popouts).
-                        (getContext != null ? getContext() : glControl.Context).MakeCurrent();
+                        // These surfaces must live in the host context, recreate them there.
+                        hostGlContext.MakeCurrent();
                         DeleteMainSurfaces();
                         transparencyRenderer.SetDimensions(glControl.Width, glControl.Height);
                         InitMainSurfaces();
@@ -372,9 +383,7 @@ namespace STROOP.Tabs.MapTab
 
         private void OnPaint()
         {
-            // Everything is rendered in the "render context": our own context for the main map, or the
-            // main map's shared context for popouts. Make it current before any GL call (incl. GL init).
-            (getContext != null ? getContext() : glControl.Context).MakeCurrent();
+            hostGlContext.MakeCurrent();
 
             PerformGLInit();
 

--- a/STROOP/Tabs/MapTab/MapPopout.cs
+++ b/STROOP/Tabs/MapTab/MapPopout.cs
@@ -9,17 +9,27 @@ namespace STROOP.Tabs.MapTab
 {
     public partial class MapPopout : Form
     {
+        // Kept so we can make the main map's (render) context current when cleaning up on close.
+        readonly MapTab tab;
         GLControl glControl;
         MapGraphics graphics;
 
         public MapPopout(MapTab tab)
         {
+            this.tab = tab;
             InitializeComponent();
             ClientSize = tab.graphics.glControl.ClientRectangle.Size;
-            glControl = new GLControl();
+            // Own GL context, but sharing resources with the main map's context so we can present the
+            // shared color texture the main context renders into. See issue #39.
+            glControl = new GLControl()
+            {
+                APIVersion = new Version(3, 3),
+                SharedContext = tab.graphics.glControl,
+            };
             glControl.Bounds = ClientRectangle;
             glControl.Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Bottom;
             Controls.Add(glControl);
+            // Render in the main map's (shared) context; present into our own context (handled in MapGraphics).
             graphics = new MapGraphics(tab, glControl, () => tab.graphics.glControl.Context);
             graphics.MapViewAngleValue = tab.graphics.MapViewAngleValue;
             graphics.MapViewScaleValue = tab.graphics.MapViewScaleValue;
@@ -36,7 +46,10 @@ namespace STROOP.Tabs.MapTab
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);
+            // The render surfaces live in the main map's context; delete them there.
+            tab.graphics.glControl.Context.MakeCurrent();
             graphics.CleanUp();
+            // Disposing our control tears down our own context (and its present-FBO).
             glControl.Dispose();
         }
     }

--- a/STROOP/Tabs/MapTab/MapPopout.cs
+++ b/STROOP/Tabs/MapTab/MapPopout.cs
@@ -1,22 +1,17 @@
-﻿using OpenTK;
-using System;
+﻿using System;
 using System.Windows.Forms;
 using OpenTK.GLControl;
 using STROOP.Core;
-using STROOP.Utilities;
 
 namespace STROOP.Tabs.MapTab
 {
     public partial class MapPopout : Form
     {
-        // Kept so we can make the main map's (render) context current when cleaning up on close.
-        readonly MapTab tab;
         GLControl glControl;
         MapGraphics graphics;
 
         public MapPopout(MapTab tab)
         {
-            this.tab = tab;
             InitializeComponent();
             ClientSize = tab.graphics.glControl.ClientRectangle.Size;
             // Own GL context, but sharing resources with the main map's context so we can present the
@@ -46,10 +41,7 @@ namespace STROOP.Tabs.MapTab
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);
-            // The render surfaces live in the main map's context; delete them there.
-            tab.graphics.glControl.Context.MakeCurrent();
             graphics.CleanUp();
-            // Disposing our control tears down our own context (and its present-FBO).
             glControl.Dispose();
         }
     }


### PR DESCRIPTION

### Fix map popout rendering (#39)

**Fixes #39**

### Problem

Opening a popout from the Map tab showed nothing in the popout window and corrupted the main map's rendering (flickering when resizing the popout and dragging the main view).

### Root cause

The popout created its own window (GLControl) but reused the main map's GL context. Since Context.MakeCurrent() binds a context to its own window, the popout ended up:
- blitting its rendered image into the main window's default framebuffer (framebuffer 0 of the current context), corrupting the main map, and
- calling SwapBuffers() on its own, never-rendered window, showing nothing.

So the map was rendered correctly  it was just presented to the wrong window.

### Fix

Keep all rendering in the main map's context (renderers, collection and map objects are untouched) and only change presentation:
- The popout gets its own GL context, declared with SharedContext = <main map control>, so it can read textures the main context renders into.
- The popout still renders the map into the shared context's color texture (unchanged path).
- To present, it switches to its own context and blits that shared color texture to its window through a local present-FBO (presentFrameBuffer).
- Render surfaces are (re)created and cleaned up in the correct context on resize and close.

### Files changed

- STROOP/Tabs/MapTab/MapGraphics.cs — make the render context current before any GL call; branch the present step (main map blits directly, popout presents through its own context).
- STROOP/Tabs/MapTab/MapPopout.cs — give the popout its own SharedContext; clean up in the right context on close.

Only 2 files touched; the rendering engine is unchanged. Each hunk has an inline comment to ease review.

### Testing

- Map tab → right-click → Open Popout: the popout now displays the map.
- Repeatedly resizing the popout and dragging the main map view: no more corruption of the main map.
- Multiple popouts render correctly (object icons included, via the shared texture).

### Notes

- presentFrameBuffer is freed when the popout's context is disposed on close.