### PR TITLE
Implement dummy variables, fix variable null value handling, and consider angles as numbers

### DIFF
--- a/STROOP/Controls/VariablePanel/Cells/VariableAngleCell.cs
+++ b/STROOP/Controls/VariablePanel/Cells/VariableAngleCell.cs
@@ -6,6 +6,7 @@ namespace STROOP.Controls.VariablePanel.Cells;
 
 public class VariableAngleCell<TNumber>(VariableNumberCell<TNumber> baseCell)
     : VariableAngleCell<WinFormsVariablePanelUiContext, TNumber>(baseCell)
+    , INumberVariableCell
     where TNumber : struct, IConvertible
 {
     protected override bool DisplayAsUnsigned() => SavedSettingsConfig.DisplayYawAnglesAsUnsigned;

--- a/STROOP/Controls/VariablePanel/VariablePanel.cs
+++ b/STROOP/Controls/VariablePanel/VariablePanel.cs
@@ -34,8 +34,6 @@ namespace STROOP.Controls.VariablePanel
             tab.UpdateHexDisplay();
         }
 
-        private static int numDummies = 0;
-
         public readonly Func<List<IWinFormsVariableCell>> GetSelectedVars;
 
         public Func<IEnumerable<(string name, SpecialFuncVariables generateVariables)>> getSpecialFuncVariables = null;

--- a/STROOP/Controls/VariablePanel/VariablePanel.cs
+++ b/STROOP/Controls/VariablePanel/VariablePanel.cs
@@ -411,19 +411,17 @@ namespace STROOP.Controls.VariablePanel
 
         private static CustomVariable CreateDummyVariable<T>() where T : struct, IConvertible
         {
-            throw new NotImplementedException();
-            // T capturedValue = default(T);
-            //
-            // return new CustomVariableView<T>(VariableUtilities.GetWrapperType(typeof(T)))
-            // {
-            //     Name = $"Dummy {++numDummies} {StringUtilities.Capitalize(typeof(T).Name)}",
-            //     _getterFunction = () => capturedValue.Yield(),
-            //     _setterFunction = (T value) =>
-            //     {
-            //         capturedValue = value;
-            //         return true.Yield();
-            //     }
-            // };
+            T capturedValue = default(T);
+
+            var variable = new CustomVariable<T>("Number");
+            variable.getter = () => capturedValue.Yield();
+            variable.setter = value =>
+            {
+                capturedValue = value;
+                return true.Yield();
+            };
+
+            return variable;
         }
 
         private ToolStripMenuItem CreateFilterItem(string varGroup)

--- a/STROOP/Utilities/VariableSelectionUtilities.cs
+++ b/STROOP/Utilities/VariableSelectionUtilities.cs
@@ -27,7 +27,10 @@ namespace STROOP.Structs
             => cells.OfType<INumberVariableCell>().Where(x => x is not IVariableCellData<string>);
 
         static double GetNumberValue(this INumberVariableCell cell)
-            => (double)(Convert.ChangeType(cell.CombineValues().value, TypeCode.Double) ?? double.NaN);
+        {
+            var cellValue = cell.CombineValues().value;
+            return cellValue == null ? double.NaN : (double)(Convert.ChangeType(cellValue, TypeCode.Double));
+        }
 
         static bool SetValue(this INumberVariableCell cell, double value)
             => cell.TrySetValue(value.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
- resolves #57 
- fixes a crash stemming from null values in binary math operation variables
- angle variables are now considered as number variables so that binary math can be performed on them